### PR TITLE
Add Simulation control

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,9 +1,11 @@
-import { useState } from 'react';
 import './init';
 import './App.css';
-import SimulationParameter from './SimulationParameter'
-import Visulaization from './Visualization'
-import PushButton from './widgets/push-button/PushButton'
+import { useState } from 'react';
+import PushButton from './widgets/push-button/PushButton';
+import SimulationParameter from './SimulationParameter';
+import Visulaization from './Visualization';
+import SimulationControl from './SimulationControl';
+
 
 function App() {
 
@@ -30,7 +32,7 @@ function App() {
             </div>
           }
         </div>
-        <div>Simulation Control</div>
+        <SimulationControl/>
       </div>
     </div>
   )

--- a/src/SimulationControl.css
+++ b/src/SimulationControl.css
@@ -1,0 +1,9 @@
+
+.mainContent {
+    display: flex;
+    flex-direction: column;
+}
+
+.btn {
+    padding: 5px;
+}

--- a/src/SimulationControl.jsx
+++ b/src/SimulationControl.jsx
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+import { sendData, subscribe } from './services/ApiService';
+import PushButton from './widgets/push-button/PushButton'
+import './SimulationControl.css'
+
+function SimulationControl() {
+
+    const [isSimulationRunning, setIsSimulationRunning] = useState(false)
+
+    const onCreateSimulation = () => {
+        sendData('create_simulation')
+    }
+
+    const onSimulate = () => {
+        sendData('simulate')
+        subscribe('simulation_running', (data) => {
+            setIsSimulationRunning(data);
+          })
+    }
+
+    return (
+        <div className='mainContent'>
+            <PushButton className='btn' onClick={onCreateSimulation} label="Create Simulation" disabled={isSimulationRunning}/>
+            <PushButton className='btn' onClick={onSimulate} label="Simulate" disabled={isSimulationRunning}/>
+            { isSimulationRunning && <label>simulation running</label> }
+        </div>
+    )
+}
+
+export default SimulationControl;

--- a/src/widgets/push-button/PushButton.jsx
+++ b/src/widgets/push-button/PushButton.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-const PushButton = ({ onClick, label }) => {
+const PushButton = ({ onClick, label, disabled }) => {
 
   // Function to handle button click
   const handleClick = () => {
@@ -9,7 +9,7 @@ const PushButton = ({ onClick, label }) => {
   };
 
   return (
-    <button onClick={handleClick}>{label}</button>
+    <button onClick={handleClick} disabled={disabled}>{label}</button>
   );
 };
 


### PR DESCRIPTION
The Simulation Control part is added where the user can create a new simulation and the new parameters of the simulation are displayed. Also the user can run the simulation and get a notification that the simulation is running.

![simulation_control](https://github.com/HishamSaeed/fenicsWeb_frontend/assets/56412683/6db143c8-712b-4d6e-b4f6-2405ab157c49)
